### PR TITLE
Fixing 500 server error response when user with digital id already exists

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+      <version>5.7.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>

--- a/api/src/main/java/ca/bc/gov/educ/api/edx/repository/EdxUserRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/edx/repository/EdxUserRepository.java
@@ -14,6 +14,8 @@ public interface EdxUserRepository extends JpaRepository<EdxUserEntity, UUID>, E
 
   List<EdxUserEntity> findEdxUserEntitiesByDigitalIdentityID(UUID digitalIdentityID);
 
+  boolean existsByDigitalIdentityID(UUID digitalIdentityID);
+
   @Query(value = " SELECT DISTINCT EMAIL\n" +
     "FROM EDX_USER\n" +
     "WHERE EDX_USER_ID IN (SELECT ES.EDX_USER_ID\n" +

--- a/api/src/main/java/ca/bc/gov/educ/api/edx/service/v1/EdxUsersService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/edx/service/v1/EdxUsersService.java
@@ -12,7 +12,6 @@ import ca.bc.gov.educ.api.edx.struct.v1.EdxActivationCode;
 import ca.bc.gov.educ.api.edx.struct.v1.EdxPrimaryActivationCode;
 import ca.bc.gov.educ.api.edx.struct.v1.EdxUser;
 import ca.bc.gov.educ.api.edx.utils.TransformUtil;
-import ca.bc.gov.educ.api.edx.utils.UUIDUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -214,6 +213,10 @@ public class EdxUsersService {
     mapEdxUserSchoolAndRole(edxUserEntity);
 
     mapEdxUserDistrictAndRole(edxUserEntity);
+
+    if(this.getEdxUserRepository().existsByDigitalIdentityID(edxUserEntity.getDigitalIdentityID())){
+      throw new EntityExistsException(String.format("digitalIdentityId must be unique. EdxUser with digitalIdentityID: %s already exists", edxUserEntity.getDigitalIdentityID()));
+    }
 
     return this.getEdxUserRepository().save(edxUserEntity);
   }

--- a/api/src/test/java/ca/bc/gov/educ/api/edx/controller/EdxUsersControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/edx/controller/EdxUsersControllerTest.java
@@ -24,7 +24,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -209,6 +212,21 @@ public class EdxUsersControllerTest extends BaseSecureExchangeControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_EDX_USERS"))))
       .andDo(print()).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void testCreateEdxUsers_GivenUserWithDigitalIdentityIdExists_ShouldNotCreateEntity_AndReturnResultWithBadRequestStatus() throws Exception {
+    var entity = this.createUserEntity(this.edxUserRepository, this.edxPermissionRepository, this.edxRoleRepository, this.edxUserSchoolRepository, this.edxUserDistrictRepository);
+    EdxUser edxUser = createEdxUser();
+    edxUser.setDigitalIdentityID(entity.getDigitalIdentityID().toString());
+    String json = getJsonString(edxUser);
+    this.mockMvc.perform(post(URL.BASE_URL_USERS)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json)
+        .accept(MediaType.APPLICATION_JSON)
+        .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_EDX_USER"))))
+      .andDo(print()).andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message", containsString("digitalIdentityId must be unique")));
   }
 
   @Test


### PR DESCRIPTION
When a user already exists with a unique digitalIdentityId the api should not throw a 500 but return an appropriate response code and message.